### PR TITLE
verbose logging issue fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = function (options) {
 
     browser.on('command', function(meth, path, data){
       if (options.verbose) {
-        gutil.log(' > \x1b[33m', meth, '\x1b[0m: ',  path, data || '');
+        gutil.log(' > \x1b[33m', meth, '\x1b[0m: ', path, data || '');
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -80,12 +80,12 @@ module.exports = function (options) {
     });
 
     browser.on('status', function(info){
-      gutil.log('\x1b[36m%s\x1b[0m', info);
+      gutil.log('\x1b[36m', info, '\x1b[0m');
     });
 
     browser.on('command', function(meth, path, data){
       if (options.verbose) {
-        gutil.log(' > \x1b[33m%s\x1b[0m: %s', meth, path, data || '');
+        gutil.log(' > \x1b[33m', meth, '\x1b[0m: ',  path, data || '');
       }
     });
 


### PR DESCRIPTION
So the verbose logging looked like this:
![screen shot 2015-02-06 at 5 08 26 pm](https://cloud.githubusercontent.com/assets/2551722/6088294/e0cf881a-ae22-11e4-813d-cc18c2f2065e.png)

And I fixed it so it looks like this:
![screen shot 2015-02-06 at 5 09 40 pm](https://cloud.githubusercontent.com/assets/2551722/6088313/06d854b0-ae23-11e4-8bf7-6e3e56def365.png)

I think gulp-utils' .log method doesn't accept the %s string interpolation like console.log.
